### PR TITLE
reset the result value after hitting result button

### DIFF
--- a/funwithphysics/src/Components/Classical Mechanics/Topics/Calculator.js
+++ b/funwithphysics/src/Components/Classical Mechanics/Topics/Calculator.js
@@ -42,7 +42,7 @@ function Calculator({ match }) {
                     Calculate
                 </Button>
                 &nbsp;&nbsp;&nbsp;
-                <Button variant="dark" type="reset">
+                <Button variant="dark" onClick={() => setResult(null)} type="reset">
                     Reset
                 </Button>
             </Form>
@@ -83,7 +83,7 @@ function Calculator({ match }) {
                 <Button variant="primary" onClick={handleClick}>
                     Calculate
                 </Button>&nbsp;&nbsp;&nbsp;
-                <Button variant="dark" type="reset">
+                <Button variant="dark" onClick={() => setResult(null)} type="reset">
                     Reset
                 </Button>
             </Form>
@@ -129,7 +129,7 @@ function Calculator({ match }) {
                 <Button variant="primary" onClick={handleClick}>
                     Calculate
                 </Button>&nbsp;&nbsp;&nbsp;
-                <Button variant="dark" type="reset">
+                <Button variant="dark" onClick={() => setResult(null)} type="reset">
                     Reset
                 </Button>
             </Form>
@@ -174,7 +174,7 @@ function Calculator({ match }) {
                     Calculate
                 </Button>
                 &nbsp;&nbsp;&nbsp;
-                <Button variant="dark" type="reset" >
+                <Button variant="dark" onClick={() => setResult(null)} type="reset" >
                     Reset
                 </Button>
             </Form>
@@ -228,7 +228,7 @@ function Calculator({ match }) {
                     Calculate
                 </Button>
                 &nbsp;&nbsp;&nbsp;
-                <Button variant="dark" type="reset">
+                <Button variant="dark" onClick={() => {setResultAbs(null); setResultPer(null); setResultRel(null); }} type="reset">
                     Reset
                 </Button>
             </Form>
@@ -274,7 +274,7 @@ function Calculator({ match }) {
                 <Button variant="primary" onClick={handleClick}>
                     Calculate
                 </Button>&nbsp;&nbsp;&nbsp;
-                <Button variant="dark" type="reset">
+                <Button variant="dark" onClick={() => setResult(null)} type="reset">
                     Reset
                 </Button>
             </Form>
@@ -299,10 +299,9 @@ function Calculator({ match }) {
             case "Gravitation":
                 currentCall = CalculatorGravitation();
                 break;
-
             case "Error Measurements":
-            currentCall = CalculatorErrorMeasurement();
-
+                currentCall = CalculatorErrorMeasurement();
+                break;
             case "Torque":
                 currentCall = CalculatorTorque();
 


### PR DESCRIPTION
## Related Issue

- Resets the result form value after hitting result button

Fixes: #[issue number that will be closed through this PR]

#### Describe the changes you've made

Reset the result form value after pressing the result button . 

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **![2021 08 06-15 48 23 screenshot](https://user-images.githubusercontent.com/63491234/128514119-0ad8f090-cc8e-467c-b500-bc16a8559b78.png)** | <b></b> |
