### PR TITLE
Linked Contact Us on Navbar to Footer

### DIFF
--- a/funwithphysics/src/Components/Navbar/Navbar.js
+++ b/funwithphysics/src/Components/Navbar/Navbar.js
@@ -18,6 +18,14 @@ const Navbar = () => {
     setClicked(index);
   };
 
+
+  const scrollToBottom = ()=>{
+    window.scrollTo({
+      top: document.documentElement.scrollHeight, 
+      behavior: 'smooth'
+    });
+  }
+
   return (
     <React.Fragment>
       <nav className="navbar navbar-expand-lg navbar-light bg-light pt-3">
@@ -46,7 +54,7 @@ const Navbar = () => {
             <NavLink to="/about" className="nav-item">
               <span className="nav-link">About</span>
             </NavLink>
-            <NavLink to="/contact" className="nav-item" id="contactUs">
+            <NavLink to="/contact" className="nav-item" id="contactUs" onClick={scrollToBottom} >
               <span className="nav-link">Contact</span>
             </NavLink>
             <NavLink


### PR DESCRIPTION
## Related Issue

- Contact us on navbar wasn't linked to that on footer

Fixes: #75 

#### Describe the changes you've made

I added a function to allow scrolling to contact us on footer when 'contact us' on navbar is clicked.

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Screenshot

![screencapture-localhost-3000-2021-10-01-17_33_36](https://user-images.githubusercontent.com/78212650/135616906-afc596e9-ff7b-465c-8536-6e88b3a3846f.png)

