### PR TITLE
Fix route

### DIFF
--- a/funwithphysics/src/App.js
+++ b/funwithphysics/src/App.js
@@ -20,8 +20,8 @@ const App = () => {
         <Route exact path="/classicalmechanics" component={ClassicalMechanics} />
         <Route exact path="/physics" component={physics_topic} />
         <Route exact path="/classicalmechanics/calc/:topic" component={Calculator} />
+        <Route exact path="/classicalmechanics/calc/gravitation/:topic" component={GravitationCalculator} />
         <Route exact path="/classicalmechanics/calc/:topic/:topic" component={WPECalculator} />
-        <Route exact path="/classicalmechanics/calc/:topic/:topic" component={GravitationCalculator} />
         <Redirect to="/" />
       </Switch>
     </React.Fragment>

--- a/funwithphysics/src/Components/Classical Mechanics/Topics/gravitation_Calculator.js
+++ b/funwithphysics/src/Components/Classical Mechanics/Topics/gravitation_Calculator.js
@@ -61,7 +61,7 @@ function GravitationCalculator({ match }) {
       function calCu_gravi(key) {
         let currentCall;
         switch (key) {
-            case "GravitationalForce":
+            case "Gravitational Force":
                     currentCall = CalculatorGravitationalForce();
                     break;
             default:


### PR DESCRIPTION
## Related Issue

- Info about Issue or bug

Fixes: #73 

#### Fix render gravitational force page

The last pull request failed because of two things:

1) Function calCu_gravi into switch case. I changed to this:

```
switch (key) {
            case "Gravitational Force":
```

2) And into App.js. You had two routes with same path. You need to change the path and order.

Before change:

```
<Route exact path="/classicalmechanics/calc/:topic/:topic" component={WPECalculator} />
<Route exact path="/classicalmechanics/calc/:topic/:topic" component={GravitationCalculator} />
```

After:

```
<Route exact path="/classicalmechanics/calc/gravitation/:topic" component={GravitationCalculator} />
<Route exact path="/classicalmechanics/calc/:topic/:topic" component={WPECalculator} />
```

Screenshot from my localhost:

![gravitatational-force-page](https://user-images.githubusercontent.com/20709086/135719275-e6175446-1f39-4f69-aed5-9a29610bb907.png)

